### PR TITLE
Upgrade to Quarkus 3.30.8

### DIFF
--- a/frameworks/Java/quarkus/README.md
+++ b/frameworks/Java/quarkus/README.md
@@ -13,6 +13,10 @@ There are currently 2 implementations:
 
     ./tfb --mode verify --test quarkus quarkus-hibernate-reactive
 
+After the database container image is created, it can be started independently.
+
+    docker run -d --name tfb-database -e POSTGRES_DB=hello_world -e POSTGRES_PASSWORD=benchmarkdbpass -e POSTGRES_USER=benchmarkdbuser -p 5432:5432 techempower/postgres:latest
+
 ## Versions
 
 * [Java OpenJDK 17](http://openjdk.java.net/)

--- a/frameworks/Java/quarkus/pom.xml
+++ b/frameworks/Java/quarkus/pom.xml
@@ -8,13 +8,13 @@
     <packaging>pom</packaging>
 
     <properties>
-        <compiler-plugin.version>3.14.0</compiler-plugin.version>
+        <compiler-plugin.version>3.14.1</compiler-plugin.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.21.2</quarkus.platform.version>
+        <quarkus.platform.version>3.30.8</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
         <!-- Check https://github.com/netty/netty-incubator-transport-io_uring/tags -->
@@ -61,6 +61,16 @@
     </dependencyManagement>
 
     <build>
+        <!--Required during the upgrade to Quarkus 3.30.8-->
+        <!--Otherwise, the container image build fails with:-->
+        <!--Could not find artifact io.netty:netty-transport-native-unix-common:jar:${os.detected.name}-${os.detected.arch}:4.1.130.Final in central-->
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
@@ -81,9 +91,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/frameworks/Java/quarkus/quarkus-hibernate-reactive.dockerfile
+++ b/frameworks/Java/quarkus/quarkus-hibernate-reactive.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.22 as maven
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23 as maven
 ENV LANGUAGE='en_US:en'
 
 WORKDIR /quarkus
@@ -29,7 +29,7 @@ WORKDIR /quarkus/$MODULE
 RUN mvn package -B -q
 WORKDIR /quarkus
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.22
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.23
 ENV LANGUAGE='en_US:en'
 WORKDIR /quarkus
 ENV MODULE=resteasy-reactive-hibernate-reactive

--- a/frameworks/Java/quarkus/quarkus-reactive-routes-pgclient.dockerfile
+++ b/frameworks/Java/quarkus/quarkus-reactive-routes-pgclient.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.22 as maven
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23 as maven
 ENV LANGUAGE='en_US:en'
 
 WORKDIR /quarkus
@@ -29,7 +29,7 @@ WORKDIR /quarkus/$MODULE
 RUN mvn package -B -q
 WORKDIR /quarkus
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.22
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.23
 ENV LANGUAGE='en_US:en'
 WORKDIR /quarkus
 ENV MODULE=reactive-routes-pgclient

--- a/frameworks/Java/quarkus/quarkus-vertx.dockerfile
+++ b/frameworks/Java/quarkus/quarkus-vertx.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.22 as maven
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23 as maven
 ENV LANGUAGE='en_US:en'
 
 WORKDIR /quarkus
@@ -29,7 +29,7 @@ WORKDIR /quarkus/$MODULE
 RUN mvn package -B -q
 WORKDIR /quarkus
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.22
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.23
 ENV LANGUAGE='en_US:en'
 WORKDIR /quarkus
 ENV MODULE=vertx

--- a/frameworks/Java/quarkus/quarkus.dockerfile
+++ b/frameworks/Java/quarkus/quarkus.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.22 as maven
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23 as maven
 ENV LANGUAGE='en_US:en'
 
 WORKDIR /quarkus
@@ -29,7 +29,7 @@ WORKDIR /quarkus/$MODULE
 RUN mvn package -B -q
 WORKDIR /quarkus
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.22
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.23
 ENV LANGUAGE='en_US:en'
 WORKDIR /quarkus
 ENV MODULE=resteasy-reactive-hibernate

--- a/frameworks/Java/quarkus/reactive-routes-pgclient/pom.xml
+++ b/frameworks/Java/quarkus/reactive-routes-pgclient/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -75,7 +75,7 @@
                     <dependency>
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava</artifactId>
-                        <version>32.0.0-jre</version>
+                        <version>32.0.1-jre</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/pom.xml
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/resources/application.properties
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/resources/application.properties
@@ -17,6 +17,8 @@ quarkus.hibernate-orm.second-level-caching-enabled=false
 
 #quarkus.vertx.storage=false
 
+quarkus.hibernate-orm.log.sql=false
+
 quarkus.log.console.enable=true
 quarkus.log.console.level=INFO
 quarkus.log.file.enable=false

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate/pom.xml
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -79,7 +79,7 @@
                     <dependency>
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava</artifactId>
-                        <version>32.0.0-jre</version>
+                        <version>32.0.1-jre</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
@@ -1,17 +1,13 @@
 package io.quarkus.benchmark.repository;
 
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
-import jakarta.transaction.Transactional;
-
-import org.hibernate.FlushMode;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.StatelessSession;
-
 import io.quarkus.benchmark.model.World;
 import io.quarkus.benchmark.utils.LocalRandom;
 import io.quarkus.benchmark.utils.Randomizer;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.transaction.Transactional;
+import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
 
 @Singleton
 public class WorldRepository {
@@ -59,9 +55,8 @@ public class WorldRepository {
         //We're again forced to use the "individual load" pattern by the rules:
         final World[] list = loadNWorlds(count);
         final LocalRandom random = Randomizer.current();
-        try (Session s = sf.openSession()) {
+        try (StatelessSession s = sf.openStatelessSession()) {
             s.setJdbcBatchSize(count);
-            s.setHibernateFlushMode(FlushMode.MANUAL);
             for (World w : list) {
                 //Read the one field, as required by the following rule:
                 // # vi. At least the randomNumber field must be read from the database result set.
@@ -71,7 +66,6 @@ public class WorldRepository {
                 w.setRandomNumber(random.getNextRandomExcluding(previousRead));
                 s.update(w);
             }
-            s.flush();
         }
         return list;
     }

--- a/frameworks/Java/quarkus/vertx/pom.xml
+++ b/frameworks/Java/quarkus/vertx/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -71,7 +71,7 @@
                     <dependency>
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava</artifactId>
-                        <version>32.0.0-jre</version>
+                        <version>32.0.1-jre</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
It was required to add the `os-maven-plugin`. Otherwise, the container image build fails with:

```
Could not find artifact io.netty:netty-transport-native-unix-common:jar:${os.detected.name}-${os.detected.arch}:4.1.130.Final in central
```

Also:
- Hibernate no longer has the `update` method on the regular session
- Added `quarkus.hibernate-orm.log.sql` in `application.properties`