### PR TITLE
Enable batching with StatelessSession

### DIFF
--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
@@ -51,9 +51,9 @@ public class WorldRepository extends BaseRepository {
         final List<World> worlds = new ArrayList<>(count);
         Uni<Void> loopRoot = Uni.createFrom().voidItem();
         for (int i = 0; i < count; i++) {
-            loopRoot = loopRoot.chain(() -> s.get(World.class, localRandom.getNextRandom()).invoke(worlds::add).replaceWithVoid());
+            loopRoot = loopRoot.call(() -> s.get(World.class, localRandom.getNextRandom()).invoke(worlds::add));
         }
-        return loopRoot.map(v -> worlds);
+        return loopRoot.replaceWith(worlds);
     }
 
     public Uni<List<World>> findManaged(Mutiny.Session s, int count) {
@@ -65,9 +65,9 @@ public class WorldRepository extends BaseRepository {
         final LocalRandom localRandom = Randomizer.current();
         Uni<Void> loopRoot = Uni.createFrom().voidItem();
         for (int i = 0; i < count; i++) {
-            loopRoot = loopRoot.chain(() -> s.find(World.class, localRandom.getNextRandom()).invoke(worlds::add).replaceWithVoid());
+            loopRoot = loopRoot.call(() -> s.find(World.class, localRandom.getNextRandom()).invoke(worlds::add));
         }
-        return loopRoot.map(v -> worlds);
+        return loopRoot.replaceWith(worlds);
     }
 
     public Uni<World> findStateless() {

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
@@ -24,16 +24,14 @@ public class WorldRepository extends BaseRepository {
         return inSession(s -> {
             final LocalRandom random = Randomizer.current();
             int MAX = 10000;
-            Uni<Void>[] unis = new Uni[MAX];
+            Uni<Void> loop = Uni.createFrom().voidItem();
             for (int i = 0; i < MAX; i++) {
                 final World world = new World();
                 world.setId(i + 1);
                 world.setRandomNumber(random.getNextRandom());
-                unis[i] = s.persist(world).map(v -> null);
+                loop = loop.call(() -> s.persist(world));
             }
-            return Uni.combine().all().unis(unis).with(l -> null)
-                    .flatMap(v -> s.flush())
-                    .map(v -> null);
+            return loop.call(s::flush);
         });
     }
 

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
@@ -56,20 +56,6 @@ public class WorldRepository extends BaseRepository {
         return loopRoot.replaceWith(worlds);
     }
 
-    public Uni<List<World>> findManaged(Mutiny.Session s, int count) {
-        final List<World> worlds = new ArrayList<>(count);
-        //The rules require individual load: we can't use the Hibernate feature which allows load by multiple IDs
-        // as one single operation as Hibernate is too smart and will switch to use batched loads.
-        // But also, we can't use "Uni#join" as we did in the above method as managed entities shouldn't use pipelining -
-        // so we also have to avoid Mutiny optimising things by establishing an explicit chain:
-        final LocalRandom localRandom = Randomizer.current();
-        Uni<Void> loopRoot = Uni.createFrom().voidItem();
-        for (int i = 0; i < count; i++) {
-            loopRoot = loopRoot.call(() -> s.find(World.class, localRandom.getNextRandom()).invoke(worlds::add));
-        }
-        return loopRoot.replaceWith(worlds);
-    }
-
     public Uni<World> findStateless() {
         return inStatelessSession(session -> session.get(World.class, Randomizer.current().getNextRandom()));
     }

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
@@ -37,18 +37,15 @@ public class WorldRepository extends BaseRepository {
         });
     }
 
-    public Uni<List<World>> update(Mutiny.Session session, List<World> worlds) {
-        return session
-                .setBatchSize(worlds.size())
-                .flush()
-                .map(v -> worlds);
+    public Uni<List<World>> update(Mutiny.StatelessSession session, List<World> worlds) {
+        return session.updateMultiple(worlds).replaceWith(worlds);
     }
 
     public Uni<List<World>> findStateless(int count) {
         return inStatelessSession(session -> findStateless(session, count));
     }
 
-    private Uni<List<World>> findStateless(Mutiny.StatelessSession s, int count) {
+    public Uni<List<World>> findStateless(Mutiny.StatelessSession s, int count) {
         //The rules require individual load: we can't use the Hibernate feature which allows load by multiple IDs
         // as one single operation as Hibernate is too smart and will switch to use batched loads automatically.
         // Hence, use this awkward alternative:

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/resource/DbResource.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/resource/DbResource.java
@@ -44,17 +44,14 @@ public class DbResource {
         return worldRepository.createData();
     }
 
-    private Uni<List<World>> randomWorldsForWrite(Mutiny.Session session, int count) {
-        return worldRepository.findManaged(session, count);
+    private Uni<List<World>> randomWorldsForWrite(Mutiny.StatelessSession session, int count) {
+        return worldRepository.findStateless(session, count);
     }
 
     @GET
     @Path("updates")
     public Uni<List<World>> updates(@QueryParam("queries") String queries) {
-        return worldRepository.inSession(session -> {
-
-            session.setFlushMode(FlushMode.MANUAL);
-
+        return worldRepository.inStatelessSession(session -> {
             Uni<List<World>> worlds = randomWorldsForWrite(session, parseQueryCount(queries));
             return worlds.flatMap(worldsCollection -> {
                 final LocalRandom localRandom = Randomizer.current();
@@ -66,7 +63,6 @@ public class DbResource {
                     //the verification:
                     w.setRandomNumber(localRandom.getNextRandomExcluding(previousRead));
                 } );
-
                 return worldRepository.update(session, worldsCollection);
             });
         });

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
@@ -1,5 +1,8 @@
 package io.quarkus.benchmark.repository;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.quarkus.benchmark.model.World;
 import io.quarkus.benchmark.utils.LocalRandom;
 import io.quarkus.benchmark.utils.Randomizer;
@@ -53,21 +56,22 @@ public class WorldRepository {
 
     public World[] updateNWorlds(final int count) {
         //We're again forced to use the "individual load" pattern by the rules:
-        final World[] list = loadNWorlds(count);
+        final World[] worlds = loadNWorlds(count);
+        final List<World> worldList = new ArrayList<>(worlds.length);
         final LocalRandom random = Randomizer.current();
         try (StatelessSession s = sf.openStatelessSession()) {
-            s.setJdbcBatchSize(count);
-            for (World w : list) {
+            for (World w : worlds) {
                 //Read the one field, as required by the following rule:
                 // # vi. At least the randomNumber field must be read from the database result set.
                 final int previousRead = w.getRandomNumber();
                 //Update it, but make sure to exclude the current number as Hibernate optimisations would otherwise
                 // skip the write operation:
                 w.setRandomNumber(random.getNextRandomExcluding(previousRead));
-                s.update(w);
+                worldList.add(w);
             }
+            s.updateMultiple(worldList);
         }
-        return list;
+        return worlds;
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

The first commit is the actual fix, the others are optionals.
`createData` is still using the regular session in Hibernate Reactive.